### PR TITLE
Fixed crash with video source and added compatibility with OpenCV 3.0

### DIFF
--- a/apps/rcr/rcr-track.cpp
+++ b/apps/rcr/rcr-track.cpp
@@ -137,11 +137,14 @@ int main(int argc, char *argv[])
 	bool have_face = false;
 	rcr::LandmarkCollection<cv::Vec2f> current_landmarks;
 
-	int numFrames = cap.get(CV_CAP_PROP_FRAME_COUNT); // -1 for camera
-	for (int f=1; f<=numFrames||numFrames==-1; f++)
+	for (;;)
 	{
 		cap >> image; // get a new frame from camera
-		
+
+		if (image.empty()) { // stop if we're at the end of the video
+			break;
+		}
+
 		// Note: For now, we'll just run the face detector each frame.
 		if (!have_face) {
 			// Run the face detector and obtain the initial estimate using the mean landmarks:

--- a/apps/rcr/rcr-track.cpp
+++ b/apps/rcr/rcr-track.cpp
@@ -137,7 +137,8 @@ int main(int argc, char *argv[])
 	bool have_face = false;
 	rcr::LandmarkCollection<cv::Vec2f> current_landmarks;
 
-	for (;;)
+	int numFrames = cap.get(CV_CAP_PROP_FRAME_COUNT); // -1 for camera
+	for (int f=1; f<=numFrames||numFrames==-1; f++)
 	{
 		cap >> image; // get a new frame from camera
 		

--- a/include/rcr/helpers.hpp
+++ b/include/rcr/helpers.hpp
@@ -25,6 +25,7 @@
 #include "landmark.hpp"
 
 #include "opencv2/core/core.hpp"
+#include "opencv2/imgproc/imgproc.hpp" //OpenCV 3.x
 
 #include <vector>
 


### PR DESCRIPTION
The example app `rcr-track.cpp` crashes when using a video as input image source because it does not stop the loop after the last frame.

My bugfix takes account of the limited number of frames in a video while a continuous image source (camera) behaves just like before (quit by keystroke).

Furthermore, `helpers.hpp` uses the `circle` function of OpenCV which has moved from `core` to `imgproc` in version 3.0. I don't think the additional include affects a build with OpenCV 2.x, but maybe you can test that.
