### PR TITLE
make non-class and non-template functions inline

### DIFF
--- a/include/rcr/helpers.hpp
+++ b/include/rcr/helpers.hpp
@@ -42,7 +42,7 @@ namespace rcr {
  * @param[in] landmarks The landmarks to convert to a cv::Mat row.
  * @return A cv::Mat with one row consisting of the given landmarks.
  */
-cv::Mat to_row(LandmarkCollection<cv::Vec2f> landmarks)
+inline cv::Mat to_row(LandmarkCollection<cv::Vec2f> landmarks)
 {
 	// landmarks.size() must be <= max_int
 	auto num_landmarks = static_cast<int>(landmarks.size());
@@ -63,7 +63,7 @@ cv::Mat to_row(LandmarkCollection<cv::Vec2f> landmarks)
  * @param[in] model_instance A row of 2D landmarks (e.g. an instance of a model).
  * @return A LandmarkCollection with the landmarks and their names.
  */
-LandmarkCollection<cv::Vec2f> to_landmark_collection(cv::Mat model_instance, std::vector<std::string> model_landmarks_list)
+inline LandmarkCollection<cv::Vec2f> to_landmark_collection(cv::Mat model_instance, std::vector<std::string> model_landmarks_list)
 {
 	LandmarkCollection<cv::Vec2f> collection;
 	auto num_landmarks = model_instance.cols / 2;
@@ -81,7 +81,7 @@ LandmarkCollection<cv::Vec2f> to_landmark_collection(cv::Mat model_instance, std
  * @param[in] landmarks The landmarks to draw, in the format [x_0, ... , x_n, y_0, ... , y_n].
  * @param[in] color Color of the landmarks to be drawn.
  */
-void draw_landmarks(cv::Mat image, cv::Mat landmarks, cv::Scalar color = cv::Scalar(0.0, 255.0, 0.0))
+inline void draw_landmarks(cv::Mat image, cv::Mat landmarks, cv::Scalar color = cv::Scalar(0.0, 255.0, 0.0))
 {
 	auto num_landmarks = std::max(landmarks.cols, landmarks.rows) / 2;
 	for (int i = 0; i < num_landmarks; ++i) {
@@ -96,14 +96,14 @@ void draw_landmarks(cv::Mat image, cv::Mat landmarks, cv::Scalar color = cv::Sca
  * @param[in] landmarks The landmarks to draw.
  * @param[in] color Color of the landmarks to be drawn.
  */
-void draw_landmarks(cv::Mat image, LandmarkCollection<cv::Vec2f> landmarks, cv::Scalar color = cv::Scalar(0.0, 255.0, 0.0))
+inline void draw_landmarks(cv::Mat image, LandmarkCollection<cv::Vec2f> landmarks, cv::Scalar color = cv::Scalar(0.0, 255.0, 0.0))
 {
 	draw_landmarks(image, to_row(landmarks), color);
 }
 
 // checks overlap...
 // Possible better names: check_equal, check_is_true_positive, overlap...
-bool check_face(std::vector<cv::Rect> detected_faces, LandmarkCollection<cv::Vec2f> groundtruth_landmarks)
+inline bool check_face(std::vector<cv::Rect> detected_faces, LandmarkCollection<cv::Vec2f> groundtruth_landmarks)
 {
 	// If no face is detected, return immediately:
 	if (detected_faces.empty()) {
@@ -133,7 +133,7 @@ bool check_face(std::vector<cv::Rect> detected_faces, LandmarkCollection<cv::Vec
 // Calculate the IED from one or several identifiers.
 // Several is necessary because sometimes (e.g. ibug) doesn't define the eye center.
 // throws if any of given ids not present in lms. => Todo: Think about if we should throw or use optional<>.
-double get_ied(LandmarkCollection<cv::Vec2f> lms, std::vector<std::string> right_eye_identifiers, std::vector<std::string> left_eye_identifiers)
+inline double get_ied(LandmarkCollection<cv::Vec2f> lms, std::vector<std::string> right_eye_identifiers, std::vector<std::string> left_eye_identifiers)
 {
 	// Calculate the inter-eye distance. Which landmarks to take for that is specified in the config, it
 	// might be one or two, and we calculate the average of them (per eye). For example, it might be the outer eye-corners.

--- a/include/rcr/hog.c
+++ b/include/rcr/hog.c
@@ -171,7 +171,7 @@ image edges would be oriented at 90 degrees from these.
  ** by setting @a transposed to true.
  **/
 
-VlHog * vl_hog_new (VlHogVariant variant, vl_size numOrientations, vl_bool transposed)
+inline VlHog * vl_hog_new (VlHogVariant variant, vl_size numOrientations, vl_bool transposed)
 {
   vl_index o, k ;
   VlHog * self = (VlHog*)calloc(1, sizeof(VlHog)) ;
@@ -318,7 +318,7 @@ VlHog * vl_hog_new (VlHogVariant variant, vl_size numOrientations, vl_bool trans
  ** @param self HOG object to delete.
  **/
 
-void
+inline void
 vl_hog_delete (VlHog * self)
 {
   if (self->orientationX) {
@@ -361,7 +361,7 @@ vl_hog_delete (VlHog * self)
  ** @return size (height and width) of a glyph.
  **/
 
-vl_size
+inline vl_size
 vl_hog_get_glyph_size (VlHog const * self)
 {
   return self->glyphSize ;
@@ -379,7 +379,7 @@ vl_hog_get_glyph_size (VlHog const * self)
  ** given by <code>flippedHog[i] = hog[permutation[i]]</code>.
  **/
 
-vl_index const *
+inline vl_index const *
 vl_hog_get_permutation (VlHog const * self)
 {
   return self->permutation ;
@@ -391,7 +391,7 @@ vl_hog_get_permutation (VlHog const * self)
  ** @param x @c true if orientations should be assigned with bilinear interpolation.
  **/
 
-void
+inline void
 vl_hog_set_use_bilinear_orientation_assignments (VlHog * self, vl_bool x) {
   self->useBilinearOrientationAssigment = x ;
 }
@@ -401,7 +401,7 @@ vl_hog_set_use_bilinear_orientation_assignments (VlHog * self, vl_bool x) {
  ** @return @c true if orientations are be assigned with bilinear interpolation.
  **/
 
-vl_bool
+inline vl_bool
 vl_hog_get_use_bilinear_orientation_assignments (VlHog const * self) {
   return self->useBilinearOrientationAssigment ;
 }
@@ -424,7 +424,7 @@ vl_hog_get_use_bilinear_orientation_assignments (VlHog const * self) {
  ** HOG cell.
  **/
 
-void
+inline void
 vl_hog_render (VlHog const * self,
                float * image,
                float const * descriptor,
@@ -500,7 +500,7 @@ vl_hog_render (VlHog const * self,
  ** @return imension of a HOG cell descriptors.
  **/
 
-vl_size
+inline vl_size
 vl_hog_get_dimension (VlHog const * self)
 {
   return self->dimension ;
@@ -511,7 +511,7 @@ vl_hog_get_dimension (VlHog const * self)
  ** @return number of HOG cells in the horizontal direction.
  **/
 
-vl_size
+inline vl_size
 vl_hog_get_width (VlHog * self)
 {
   return self->hogWidth ;
@@ -522,7 +522,7 @@ vl_hog_get_width (VlHog * self)
  ** @return number of HOG cells in the vertical direction.
  **/
 
-vl_size
+inline vl_size
 vl_hog_get_height (VlHog * self)
 {
   return self->hogHeight ;
@@ -536,7 +536,7 @@ vl_hog_get_height (VlHog * self)
  ** @param cellSize size of a HOG cell.
  **/
 
-static void
+inline static void
 vl_hog_prepare_buffers (VlHog * self, vl_size width, vl_size height, vl_size cellSize)
 {
   vl_size hogWidth = (width + cellSize/2) / cellSize ;
@@ -592,7 +592,7 @@ vl_hog_prepare_buffers (VlHog * self, vl_size width, vl_size height, vl_size cel
  ** pixels and not smaller than @c cellSize.
  **/
 
-void
+inline void
 vl_hog_put_image (VlHog * self,
                   float const * image,
                   vl_size width, vl_size height, vl_size numChannels,
@@ -743,6 +743,7 @@ vl_hog_put_image (VlHog * self,
  ** starting from the x axis (pointing to the right).
  **/
 
+inline
 void vl_hog_put_polar_field (VlHog * self,
                              float const * modulus,
                              float const * angle,
@@ -854,7 +855,7 @@ void vl_hog_put_polar_field (VlHog * self,
  ** ::vl_hog_get_width, ::vl_hog_get_height, and ::vl_hog_get_dimension.
  **/
 
-void
+inline void
 vl_hog_extract (VlHog * self, float * features)
 {
   vl_index x, y ;

--- a/include/rcr/hog.h
+++ b/include/rcr/hog.h
@@ -25,10 +25,14 @@ typedef long long vl_index;
 typedef unsigned long long vl_uindex;
 //#define VL_EXPORT extern "C"
 #define VL_EXPORT
+#ifdef MSVC
+#define VL_INLINE static __inline
+#else
+#define VL_INLINE static inline
+#endif
 #define VL_TRUE 1
 #define VL_FALSE 0
 #define VL_PI 3.141592653589793
-#define VL_INLINE static //__inline
 
 /** @brief Compute the minimum between two values
 ** @param x value

--- a/include/rcr/landmark.hpp
+++ b/include/rcr/landmark.hpp
@@ -52,7 +52,7 @@ template<class LandmarkType> using LandmarkCollection = std::vector<Landmark<Lan
  * @return A new, filtered LandmarkCollection.
  */
 template<class T>
-LandmarkCollection<T> filter(const LandmarkCollection<T>& landmarks, const std::vector<std::string>& filter)
+inline LandmarkCollection<T> filter(const LandmarkCollection<T>& landmarks, const std::vector<std::string>& filter)
 {
 	LandmarkCollection<T> filtered_landmarks;
 	using std::begin;

--- a/include/rcr/landmarks_io.hpp
+++ b/include/rcr/landmarks_io.hpp
@@ -40,7 +40,7 @@ namespace rcr {
  * @param[in] filename Path to a .pts file.
  * @return An ordered vector with the 68 ibug landmarks.
  */
-LandmarkCollection<cv::Vec2f> read_pts_landmarks(std::string filename)
+inline LandmarkCollection<cv::Vec2f> read_pts_landmarks(std::string filename)
 {
 	using std::getline;
 	using cv::Vec2f;

--- a/include/rcr/model.hpp
+++ b/include/rcr/model.hpp
@@ -38,6 +38,7 @@
 
 #include <vector>
 #include <string>
+#include <fstream>
 
 namespace rcr {
 
@@ -60,7 +61,7 @@ namespace rcr {
  * @param[in] translation_y Optional translation in y of the model.
  * @return A cv::Mat of the aligned points.
  */
-cv::Mat align_mean(cv::Mat mean, cv::Rect facebox, float scaling_x=1.0f, float scaling_y=1.0f, float translation_x=0.0f, float translation_y=0.0f)
+inline cv::Mat align_mean(cv::Mat mean, cv::Rect facebox, float scaling_x=1.0f, float scaling_y=1.0f, float translation_x=0.0f, float translation_y=0.0f)
 {
 	using cv::Mat;
 	// Initial estimate x_0: Center the mean face at the [-0.5, 0.5] x [-0.5, 0.5] square (assuming the face-box is that square)
@@ -188,7 +189,7 @@ private:
  * @param[in] filename Filename to a model.
  * @return The loaded detection_model.
  */
-detection_model load_detection_model(std::string filename)
+inline detection_model load_detection_model(std::string filename)
 {
 	detection_model rcr_model;
 	
@@ -206,7 +207,7 @@ detection_model load_detection_model(std::string filename)
  * @param[in] model The model to be saved.
  * @param[in] filename Filename for the model.
  */
-void save_detection_model(detection_model model, std::string filename)
+inline void save_detection_model(detection_model model, std::string filename)
 {
 	std::ofstream file(filename, std::ios::binary);
 	cereal::BinaryOutputArchive output_archive(file);

--- a/include/superviseddescent/utils/mat_serialization.hpp
+++ b/include/superviseddescent/utils/mat_serialization.hpp
@@ -53,7 +53,7 @@ namespace boost {
  * @param[in] version An optional version argument.
  */
 template<class Archive>
-void serialize(Archive& ar, cv::Mat& mat, const unsigned int /*version*/)
+inline void serialize(Archive& ar, cv::Mat& mat, const unsigned int /*version*/)
 {
 	int rows, cols, type;
 	bool continuous;


### PR DESCRIPTION
also used the definition of the `VL_INLINE` macro from 
http://www.vlfeat.org/api/portability.html#host-compiler-other

also, see #27 
